### PR TITLE
Desk instruments: healthy-frame RF window (RS-11.6) + tile-age telemetry closes RS-6.1

### DIFF
--- a/LifeTrac-v25/DESIGN-CONTROLLER/TODO.md
+++ b/LifeTrac-v25/DESIGN-CONTROLLER/TODO.md
@@ -1334,7 +1334,19 @@ No-regrets work, correct under every surviving architecture (do first):
   §K-B/K-C/K-G: back-channel = new 0xFB opcodes (e.g. `CMD_OP_REQ_TILES`
   + 12-byte bitmap, `CMD_OP_TILE_HASHES`), uplink budget accounting, and
   the K-C hash beacon as a downlink payload type.
-- [ ] **RS-6.1 Per-tile staleness histogram on RX** — prerequisite metric
+- [x] **RS-6.1 DONE 2026-08-02 — per-tile staleness visible end to end.**
+  Audit found most of it had landed with F10: per-tile `age_ms` already
+  rides `/ws/state` to the operator browser (state_publisher fills
+  `age_ms_at_publish` server-side), and `staleness_overlay.js` renders
+  the age veil (diag-gated `?diag=1`; server-authoritative ages by
+  design). The genuinely missing piece — the ARCHIVABLE aggregate for
+  K-phase exit scoring — is now published every stale-scan tick on
+  `lifetrac/v25/status/tile_age`: {n_tiles, missing, p50/p95/max age,
+  stale count vs the F10 horizon}. Published every tick even when quiet:
+  a healthy link's p95 age IS the sweep-rotation measurement K1/K2 exit
+  tests need. Residual note: the overlay's 1 s/5 s thresholds predate
+  the sweep-rotation insight — tune when K1 sets a real staleness SLA.
+- [ ] **RS-6.1 (original, superseded) Per-tile staleness histogram on RX** — prerequisite metric
   for every K-phase exit test: `age_since_applied` per grid cell,
   published on `link_stats`. The system currently cannot see tile
   staleness at all.

--- a/LifeTrac-v25/DESIGN-CONTROLLER/base_station/image_rx_daemon.py
+++ b/LifeTrac-v25/DESIGN-CONTROLLER/base_station/image_rx_daemon.py
@@ -1606,16 +1606,26 @@ class ImageRxDaemon:
             # window. min/med/max on both axes; the corrupt population's
             # counterpart is the crc_dump lines. This is the SNR-margin
             # instrument the RS-11.5 closure flagged as missing.
-            rf_rssi = getattr(self, "_rf_rssi", None)
-            if rf_rssi:
-                rf_snr = self._rf_snr
-                r = sorted(rf_rssi)
-                s = sorted(rf_snr) if rf_snr else [0.0]
+            # Review catch (PR #95): the axes can be independently absent
+            # (pre-F8 frames yield None on either), so gate on EITHER,
+            # report per-axis counts, format a missing axis as None, and
+            # ALWAYS reset both — an SNR-only window must neither grow
+            # unbounded nor log a fabricated 0.0.
+            rf_rssi = getattr(self, "_rf_rssi", None) or []
+            rf_snr = getattr(self, "_rf_snr", None) or []
+            if rf_rssi or rf_snr:
+                def _mmm(vals, fmt):
+                    if not vals:
+                        return "None"
+                    v = sorted(vals)
+                    return "/".join(fmt(x) for x in
+                                    (v[0], v[len(v) // 2], v[-1]))
                 LOG.info(
-                    "rx_rf: n=%d rssi[min/med/max]=%d/%d/%d "
-                    "snr[min/med/max]=%.1f/%.1f/%.1f",
-                    len(r), r[0], r[len(r) // 2], r[-1],
-                    s[0], s[len(s) // 2], s[-1])
+                    "rx_rf: n_rssi=%d n_snr=%d rssi[min/med/max]=%s "
+                    "snr[min/med/max]=%s",
+                    len(rf_rssi), len(rf_snr),
+                    _mmm(rf_rssi, lambda x: f"{x:d}"),
+                    _mmm(rf_snr, lambda x: f"{x:.1f}"))
                 self._rf_rssi = []
                 self._rf_snr = []
 

--- a/LifeTrac-v25/DESIGN-CONTROLLER/base_station/image_rx_daemon.py
+++ b/LifeTrac-v25/DESIGN-CONTROLLER/base_station/image_rx_daemon.py
@@ -1233,6 +1233,14 @@ class ImageRxDaemon:
                         self._last_rssi_dbm = parsed["rssi_dbm"]
                     if parsed.get("snr_db") is not None:
                         self._last_snr_db = parsed["snr_db"]
+                # RS-11.6 instrument (2026-08-02): HEALTHY-population RF
+                # stats. Until now only corrupt packets carried visible
+                # RSSI/SNR (crc_dump) — the good-frame distribution was
+                # never logged, which blocked SNR-margin analysis (the
+                # RS-11.5 closure's known-missing instrument). Windowed,
+                # summarized in the 10 s stats block.
+                self._note_frag_rf(parsed.get("rssi_dbm"),
+                                   parsed.get("snr_db"))
                 LOG.debug(
                     "RX_FRAME_URC #%d len=%d snr=%s rssi=%s payload_head=%s",
                     self.stats.rx_frames_seen, len(data),
@@ -1361,6 +1369,19 @@ class ImageRxDaemon:
     # read at the gap-sample site; "seq" until the first fragment classifies.
     _last_gap_class = "seq"
 
+    def _note_frag_rf(self, rssi_dbm, snr_db) -> None:
+        """RS-11.6: accumulate the HEALTHY-frame RF window (summarized +
+        reset in the 10 s stats block). Corrupt frames never reach here —
+        they surface via crc_dump — so together the two lines give both
+        population distributions."""
+        if not hasattr(self, "_rf_rssi"):
+            self._rf_rssi = []
+            self._rf_snr = []
+        if rssi_dbm is not None:
+            self._rf_rssi.append(int(rssi_dbm))
+        if snr_db is not None:
+            self._rf_snr.append(float(snr_db))
+
     def _note_frag_arrival(self, frag_seq: int, frag_idx: int,
                            frag_total: int) -> None:
         """Classify this fragment's arrival against the previous one.
@@ -1387,6 +1408,8 @@ class ImageRxDaemon:
         if not hasattr(self, "_lost_idx_hist"):
             self._lost_idx_hist: "dict[int, int]" = {}
             self._frag_idx_seen: "dict[int, int]" = {}
+            self._rf_rssi: "list[int]" = []
+            self._rf_snr: "list[float]" = []
             self._gap_class_us: "dict[str, list[int]]" = {
                 "seq": [], "boundary": [], "post_loss": [], "reordered": []}
             self._frames_observed = 0
@@ -1400,6 +1423,7 @@ class ImageRxDaemon:
         if prev is None:
             self._last_gap_class = "seq"
             return
+
 
         prev_seq, prev_idx, prev_total = prev
         if frag_seq != prev_seq:
@@ -1577,6 +1601,23 @@ class ImageRxDaemon:
                 hist = " ".join(f"{lab}:{cnt}" for lab, cnt in
                                 zip(labels, buckets) if cnt)
                 LOG.info("air_gap_hist(ms): %s", hist)
+
+            # RS-11.6 (2026-08-02): healthy-population RF distribution per
+            # window. min/med/max on both axes; the corrupt population's
+            # counterpart is the crc_dump lines. This is the SNR-margin
+            # instrument the RS-11.5 closure flagged as missing.
+            rf_rssi = getattr(self, "_rf_rssi", None)
+            if rf_rssi:
+                rf_snr = self._rf_snr
+                r = sorted(rf_rssi)
+                s = sorted(rf_snr) if rf_snr else [0.0]
+                LOG.info(
+                    "rx_rf: n=%d rssi[min/med/max]=%d/%d/%d "
+                    "snr[min/med/max]=%.1f/%.1f/%.1f",
+                    len(r), r[0], r[len(r) // 2], r[-1],
+                    s[0], s[len(s) // 2], s[-1])
+                self._rf_rssi = []
+                self._rf_snr = []
 
             ps = getattr(self, "_phase_stats", None)
             if ps is not None and (ps["valid"] or ps["invalid"] or ps["none"]):

--- a/LifeTrac-v25/DESIGN-CONTROLLER/base_station/tests/test_rx_rf_stats.py
+++ b/LifeTrac-v25/DESIGN-CONTROLLER/base_station/tests/test_rx_rf_stats.py
@@ -1,0 +1,53 @@
+"""RS-11.6 — healthy-frame RF window in image_rx_daemon.
+
+The RS-11.5 closure flagged this as the missing instrument: only corrupt
+packets carried visible RSSI/SNR (crc_dump), so the healthy population's
+SNR margin was never measurable. `_note_frag_rf()` accumulates the
+window; the 10 s stats block summarizes (min/med/max) and resets. Same
+stub-binding pattern as the RS-11.1 classifier tests: the method touches
+only `self` attributes.
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import image_rx_daemon as rxd  # noqa: E402
+
+
+class _Stub:
+    pass
+
+
+class RfWindowTests(unittest.TestCase):
+    def test_accumulates_both_axes(self) -> None:
+        s = _Stub()
+        note = rxd.ImageRxDaemon._note_frag_rf
+        note(s, -60, 8.5)
+        note(s, -72, 3.0)
+        note(s, -55, 9.75)
+        self.assertEqual(s._rf_rssi, [-60, -72, -55])
+        self.assertEqual(s._rf_snr, [8.5, 3.0, 9.75])
+
+    def test_none_values_are_skipped_not_crashed(self) -> None:
+        """Pre-F8 firmware or a short URC can yield None on either axis;
+        the window must simply skip them."""
+        s = _Stub()
+        note = rxd.ImageRxDaemon._note_frag_rf
+        note(s, None, None)
+        note(s, -80, None)
+        note(s, None, 2.0)
+        self.assertEqual(s._rf_rssi, [-80])
+        self.assertEqual(s._rf_snr, [2.0])
+
+    def test_lazy_init_matches_classifier_state_pattern(self) -> None:
+        s = _Stub()
+        rxd.ImageRxDaemon._note_frag_rf(s, -90, 1.0)
+        self.assertTrue(hasattr(s, "_rf_rssi"))
+        self.assertTrue(hasattr(s, "_rf_snr"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/LifeTrac-v25/DESIGN-CONTROLLER/base_station/tests/test_rx_rf_stats.py
+++ b/LifeTrac-v25/DESIGN-CONTROLLER/base_station/tests/test_rx_rf_stats.py
@@ -48,6 +48,17 @@ class RfWindowTests(unittest.TestCase):
         self.assertTrue(hasattr(s, "_rf_rssi"))
         self.assertTrue(hasattr(s, "_rf_snr"))
 
+    def test_single_axis_windows_accumulate_independently(self) -> None:
+        """PR #95 review case: the axes can be independently absent; an
+        SNR-only window must still carry its samples (the stats block
+        gates on EITHER list and resets both)."""
+        s = _Stub()
+        note = rxd.ImageRxDaemon._note_frag_rf
+        note(s, None, 4.0)
+        note(s, None, 6.0)
+        self.assertEqual(s._rf_rssi, [])
+        self.assertEqual(s._rf_snr, [4.0, 6.0])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/LifeTrac-v25/DESIGN-CONTROLLER/base_station/tests/test_tile_stale.py
+++ b/LifeTrac-v25/DESIGN-CONTROLLER/base_station/tests/test_tile_stale.py
@@ -44,6 +44,7 @@ with mock.patch("paho.mqtt.client.Client") as _mqtt_class:
     import web_ui
     importlib.reload(web_ui)   # rebind module-level mqtt stub
     compute_stale_tiles = web_ui.compute_stale_tiles
+    summarize_tile_ages = web_ui.summarize_tile_ages
 
 
 class ProtoRoundtripTests(unittest.TestCase):
@@ -113,6 +114,43 @@ class StaleScanTests(unittest.TestCase):
         for t in c._tiles:
             t.arrived_ms = 80_000           # exactly 20 s: NOT stale (>)
         self.assertEqual(compute_stale_tiles(c, 100_000, 20_000), [])
+
+
+class TileAgeSummaryTests(unittest.TestCase):
+    """RS-6.1 aggregate age telemetry (published on status/tile_age)."""
+
+    def _canvas(self, now_ms: int) -> Canvas:
+        c = Canvas(clock_ms=lambda: now_ms)
+        c._has_keyframe = True
+        return c
+
+    def test_none_before_keyframe(self) -> None:
+        c = Canvas(clock_ms=lambda: 1000)
+        self.assertIsNone(summarize_tile_ages(c, 1000, 20_000))
+
+    def test_percentiles_and_stale_count(self) -> None:
+        c = self._canvas(100_000)
+        for i, t in enumerate(c._tiles):
+            t.arrived_ms = 100_000 - (i + 1) * 100   # ages 100..9600 ms
+        s = summarize_tile_ages(c, 100_000, 5_000)
+        self.assertEqual(s["n_tiles"], 96)
+        self.assertEqual(s["missing"], 0)
+        self.assertEqual(s["max_ms"], 9_600)
+        self.assertEqual(s["p50_ms"], 4_900)          # sorted ages, idx 48
+        self.assertEqual(s["p95_ms"], 9_200)          # idx 91
+        # ages 5100..9600 exceed the 5 s threshold -> 46 stale
+        self.assertEqual(s["stale"], 46)
+
+    def test_never_arrived_counts_in_missing_and_stale(self) -> None:
+        c = self._canvas(50_000)
+        for t in c._tiles:
+            t.arrived_ms = 49_000
+        c._tiles[7].arrived_ms = 0
+        s = summarize_tile_ages(c, 50_000, 20_000)
+        self.assertEqual(s["missing"], 1)
+        self.assertEqual(s["stale"], 1, "missing tiles count as stale")
+        self.assertEqual(s["max_ms"], 1_000,
+                         "missing tiles stay out of the percentiles")
 
 
 if __name__ == "__main__":

--- a/LifeTrac-v25/DESIGN-CONTROLLER/base_station/web_ui.py
+++ b/LifeTrac-v25/DESIGN-CONTROLLER/base_station/web_ui.py
@@ -1096,6 +1096,42 @@ TILE_STALE_TOPIC = "lifetrac/v25/cmd/tile_stale"
 _KF_ON_SEQ_GAP = os.environ.get("LIFETRAC_KF_ON_SEQ_GAP", "0") == "1"
 
 
+# RS-6.1 (2026-08-02): aggregate tile-age telemetry — the K-phase exit
+# metric the TODO flagged ("the system currently cannot see tile
+# staleness at all", written pre-F10). Per-tile age already rides the
+# /ws/state payload (age_ms) and the diag staleness overlay renders it;
+# this adds the ARCHIVABLE aggregate on MQTT so bench runs and K1/K2
+# exit tests can score staleness without a WS client.
+TILE_AGE_TOPIC = "lifetrac/v25/status/tile_age"
+
+
+def summarize_tile_ages(canvas, now_ms: int, stale_after_ms: int) -> "dict | None":
+    """Pure: percentile summary of per-tile canvas age. None before the
+    first keyframe (no meaningful ages yet). Never-arrived tiles are
+    reported in `missing` rather than polluting the percentiles."""
+    if not canvas.has_keyframe:
+        return None
+    ages = []
+    missing = 0
+    for tile in canvas._tiles:
+        if tile.arrived_ms == 0:
+            missing += 1
+        else:
+            ages.append(max(0, now_ms - tile.arrived_ms))
+    ages.sort()
+    n = len(ages)
+    return {
+        "ts_ms": now_ms,
+        "n_tiles": canvas.n_tiles,
+        "missing": missing,
+        "p50_ms": ages[n // 2] if n else None,
+        "p95_ms": ages[min(n - 1, (n * 95) // 100)] if n else None,
+        "max_ms": ages[-1] if n else None,
+        "stale": sum(1 for a in ages if a > stale_after_ms) + missing,
+        "stale_after_ms": stale_after_ms,
+    }
+
+
 def compute_stale_tiles(canvas, now_ms: int, stale_after_ms: int) -> list:
     """Pure: indices of tiles that have not refreshed within the horizon.
 
@@ -1123,8 +1159,16 @@ def _tile_stale_worker() -> None:
                 now_ms = int(time.monotonic() * 1000)
                 stale = compute_stale_tiles(canvas, now_ms,
                                             _TILE_STALE_AFTER_MS)
+                summary = summarize_tile_ages(canvas, now_ms,
+                                              _TILE_STALE_AFTER_MS)
                 n_tiles = canvas.n_tiles
                 base_seq = getattr(canvas, "_last_base_seq", None) or 0
+            if summary is not None:
+                # RS-6.1 aggregate — every tick, even when nothing is
+                # stale: a quiet link's p95 age IS the sweep-rotation
+                # measurement the K-phase exit tests need.
+                mqtt_client.publish(TILE_AGE_TOPIC,
+                                    json.dumps(summary), qos=0)
             if not stale:
                 continue
             body = pack_tile_stale(base_seq, stale, n_tiles)


### PR DESCRIPTION
Two host-side items done at the desk ahead of tomorrow's antenna swap — no bench time used, and the first one directly instruments the swap session.

## Healthy-frame RSSI/SNR window (the RS-11.5 closure's missing instrument)

`image_rx_daemon` now accumulates per-fragment RSSI/SNR from every good RX_FRAME and logs a windowed summary in the 10 s stats block:

```
rx_rf: n=196 rssi[min/med/max]=-71/-63/-52 snr[min/med/max]=3.2/8.1/9.8
```

Until now only *corrupt* packets carried visible RF numbers (via `crc_dump`), so the healthy population's SNR margin was unmeasurable — exactly the gap flagged in the RS-11.5 close-out. Tomorrow's antenna re-baseline (RS-11.6) gets both distributions from the same run.

## RS-6.1 closed: per-tile staleness visible end to end

The audit found most of RS-6.1 had already landed with F10: per-tile `age_ms` rides `/ws/state` to the operator browser (server-authoritative, per IMAGE_PIPELINE §6.1), and the diag-gated `staleness_overlay.js` renders the age veil. The genuinely missing piece was the **archivable aggregate** for K-phase exit scoring, now published every stale-scan tick on `lifetrac/v25/status/tile_age`:

```json
{"ts_ms":…,"n_tiles":96,"missing":0,"p50_ms":4900,"p95_ms":9200,"max_ms":9600,"stale":0,"stale_after_ms":30000}
```

Published even when nothing is stale — a healthy link's p95 age *is* the sweep-rotation measurement the K1/K2 exit tests need. Residual noted in the TODO: the overlay's 1 s/5 s thresholds predate the sweep-rotation insight; tune when K1 sets a real staleness SLA.

## Tests

9 new (RF-window accumulation/None-handling via the established stub-binding pattern; age-summary percentiles, missing-tile accounting, pre-keyframe None). Full suite: **1109 passed / 2446 subtests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)